### PR TITLE
Remove escaping pre template

### DIFF
--- a/django/repository/templatetags/markdownify.py
+++ b/django/repository/templatetags/markdownify.py
@@ -8,13 +8,22 @@ from django.template.defaultfilters import stringfilter
 register = template.Library()
 
 
+def deduplicate_escape(text):
+    return (text
+            .replace("&amp;lt;", "&lt;")
+            .replace("&amp;gt;", "&gt;")
+            .replace("&amp;quot;", "&quot;")
+            .replace("&amp;#39;", "&#39;")
+            )
+
+
 @register.filter
 @stringfilter
 def markdownify(value):
-    return mark_safe(markdown.markdown(
+    return mark_safe(deduplicate_escape(markdown.markdown(
         escape(value),
         extensions=[
             "markdown.extensions.fenced_code",
             "markdown.extensions.tables",
         ]
-    ))
+    )))


### PR DESCRIPTION
The template will escape everything hitting it anyway.

Tested with https://thunderstore.io/package/ToyDragon/SharedModLibrary/ and its now all the quotation marks are actually `"` and not `&quot;`