### PR TITLE
Update color of the 'rated' icon

### DIFF
--- a/builder/src/scss/general.scss
+++ b/builder/src/scss/general.scss
@@ -14,7 +14,7 @@
 }
 
 .rated {
-    color: blue!important;
+    color: #3498db!important;
 }
 
 .clickable {


### PR DESCRIPTION
I feel as though the deep blue of the rated mods looked out of place on the site. I've changed the icon color to be a lighter blue (#3498db, the current color of the alert banner near the top of the page) to better match the color scheme.