### PR TITLE
Add the 'fa-globe' icon to the website link

### DIFF
--- a/django/repository/templates/repository/package_detail.html
+++ b/django/repository/templates/repository/package_detail.html
@@ -45,7 +45,9 @@
         <div class="d-flex w-100 justify-content-between">
             <h5 class="mb-1">By <a href="{{ object.owner_url }}">{{ object.owner.name }}</a></h5>
             {% if object.website_url %}
-            <a class="text-nowrap" href="{{ object.website_url }}">{{ object.website_url }}</a>
+            <a class="text-nowrap" href="{{ object.website_url }}">
+              <span class="fa fa-globe fa-fw"></span>
+              {{ object.website_url }}</a>
             {% endif %}
         </div>
     </div>

--- a/django/repository/templates/repository/package_detail.html
+++ b/django/repository/templates/repository/package_detail.html
@@ -46,7 +46,7 @@
             <h5 class="mb-1">By <a href="{{ object.owner_url }}">{{ object.owner.name }}</a></h5>
             {% if object.website_url %}
             <a class="text-nowrap" href="{{ object.website_url }}">
-              <span class="fa fa-globe fa-fw"></span>
+              <span class="fa fa-globe-americas fa-fw"></span>
               {{ object.website_url }}</a>
             {% endif %}
         </div>


### PR DESCRIPTION
Adds the 'fa-globe' icon to the website link on package detail pages.

Original: https://funkfrog.me/cjAXDDwRiZ.png

Modified: https://funkfrog.me/ZIaAG70DIb.png

Resolves issue #19 