### PR TITLE
Add link to the API documentation

### DIFF
--- a/django/frontend/templates/base.html
+++ b/django/frontend/templates/base.html
@@ -40,6 +40,9 @@
                     </li>
                 {% endif %}
                 <li class="nav-item">
+                    <a class="nav-link" href="https://thunderstore.io/api/docs/">API Docs</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link" href="https://discord.gg/5MbXZvd"><span class="fab fa-discord"></span> &nbsp;Join our Discord</a>
                 </li>
             </ul>


### PR DESCRIPTION
Adds a link to the API docs in the navbar. 

Before: https://funkfrog.me/kOQluONGTD.png

After:
https://funkfrog.me/QlojN6yZ6H.png Regular Monitor Width
https://funkfrog.me/9FhriVUqGG.png iPhone X
https://funkfrog.me/1rGxj8joOI.png iPad
https://funkfrog.me/L7z8BetsRI.png Galaxy S9

Resolves #21