### PR TITLE
Update color of the "potentially outdated package" button

### DIFF
--- a/builder/src/scss/theme/_bootswatch.scss
+++ b/builder/src/scss/theme/_bootswatch.scss
@@ -217,6 +217,10 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic"
   }
 }
 
+.alert-secondary {
+    background-color: #d47618;
+}
+
 // Progress bars ===============================================================
 
 // Containers ==================================================================


### PR DESCRIPTION
Current appearance: https://funkfrog.me/0hERwqiH9O.png 
Updated appearance: https://funkfrog.me/dxPwhWDhq8.png

Updates the color from the default #444 to #d47618 to make it more noticeable!