### PR TITLE
Separate push steps in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
         run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+      - name: Push image to Docker Hub
+        run: docker push riskofthunder/thunderstore
       - name: Login to GitHub Container Registry
         env:
           DOCKER_USERNAME: ${{ secrets.GHCR_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.GHCR_PAT }}
         run: docker login ghcr.io -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-      - name: Push image
-        run: |
-          docker push riskofthunder/thunderstore
-          docker push ghcr.io/risk-of-thunder/thunderstore
+      - name: Push image to GitHub Container Registry
+        run: docker push ghcr.io/risk-of-thunder/thunderstore


### PR DESCRIPTION
Minor change so that pushing the images in the release workflow are in separate steps to mirror the test workflow

This also makes the workflow slightly more resilient in case logging in to GHCR fails
