### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/django/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot security updates should also [be enabled](https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories)

![](https://github.blog/wp-content/uploads/2020/05/enable-automated-security-updates.gif)