### PR TITLE
Upload code coverage even if tests fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
           thunderstore:${GITHUB_SHA}
           --cov-report=xml:coverage_results/coverage.xml
       - name: Upload coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage_results/coverage.xml


### PR DESCRIPTION
I don't think it is possible to only run it if tests is the one that fails (so it might try to upload coverage even if the first step failed) but this shouldn't really be an issue as the job failed anyway
