### PR TITLE
Remove default pytest cov args

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
           --no-healthcheck
           thunderstore:${GITHUB_SHA}
           --cov-report=xml:coverage_results/coverage.xml
+          --cov-report=term
           --cov /app/
       - name: Upload coverage to Codecov
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
           --no-healthcheck
           thunderstore:${GITHUB_SHA}
           --cov-report=xml:coverage_results/coverage.xml
+          --cov /app/
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v1

--- a/django/pytest.ini
+++ b/django/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = thunderstore.core.settings
 norecursedirs = static var htmlcov
-addopts = --reuse-db --nomigrations --cov . --cov-report=html --cov-report=term
+addopts = --reuse-db --nomigrations
 env =
     DATABASE_URL=sqlite:///tmp/django.db
     DEBUG="True"


### PR DESCRIPTION
In general this is not required, especially with codecov now in use for every pushed commit. External tools (e.g. IDE integrations) don't need this data which adds extra time for something that probably makes more sense to be opt-in anyway as when it is used, it is used with `docker-compose exec`, meaning any needed coverage options can be added easily
