### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.8-buster
+
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update \
+&& apt-get install -y \
+  curl build-essential sudo git \
+&& rm -rf /var/lib/apt/lists/*
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+&& useradd -mrs /bin/bash --uid $USER_UID --gid $USER_GID $USERNAME \
+&& echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+&& chmod 0440 /etc/sudoers.d/$USERNAME
+
+RUN mkdir -p /workspace/django/var && chown -R $USERNAME:$USERNAME /workspace
+
+USER $USERNAME
+ENV PATH /home/$USERNAME/.local/bin:$PATH
+
+RUN pip install -U pip poetry~=1.1.4 --no-cache-dir && \
+    poetry config virtualenvs.in-project true
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,69 @@
+{
+    "name": "Thunderstore",
+    "dockerComposeFile": ["../docker-compose.yml", "docker-compose.yml"],
+    "service": "django",
+    "workspaceFolder": "/workspace",
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash",
+        "files.exclude": {
+            "**/.git": true,
+            "**/.DS_Store": true,
+            "**/__pycache__/": true,
+            "**/.pytest_cache/": true,
+            "**/.mypy_cache/": true,
+            "**/*.egg-info/": true,
+            "**/.venv/": true,
+            "**/.coverage": true,
+            "**/htmlcov/": true
+        },
+        "python.analysis.extraPaths": ["/workspace/django/"],
+        "python.formatting.provider": "black",
+        "python.languageServer": "Pylance",
+        "python.analysis.typeCheckingMode": "basic",
+        "python.linting.mypyArgs": [
+            "--follow-imports=silent",
+            "--show-column-numbers",
+            "--config-file",
+            "/workspace/django/.mypy.ini"
+        ],
+        "python.linting.mypyEnabled": true,
+        "python.pythonPath": "/workspace/django/.venv/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+            "--no-cov",
+            "-c",
+            "/workspace/django/pytest.ini",
+            "/workspace/django/"
+        ],
+        "python.testing.unittestEnabled": false,
+        "python.testing.nosetestsEnabled": false,
+        "python.linting.flake8Enabled": true,
+        "[python]": {
+            "editor.rulers": [88]
+        },
+        "files.associations": {
+            "**/*.html": "html",
+            "**/templates/**/*.html": "django-html"
+        },
+        "emmet.includeLanguages": {
+            "django-html": "html"
+        }
+    },
+    "extensions": [
+        "ms-python.python",
+        "bungcip.better-toml",
+        "streetsidesoftware.code-spell-checker",
+        "batisteo.vscode-django",
+        "editorconfig.editorconfig",
+        "eamodio.gitlens",
+        "esbenp.prettier-vscode",
+        "visualstudioexptteam.vscodeintellicode",
+        "redhat.vscode-yaml",
+        "ms-python.vscode-pylance"
+    ],
+    "postCreateCommand": [
+        "/bin/bash",
+        "/workspace/.devcontainer/postAttach.sh"
+    ],
+    "postAttachCommand": ["/bin/bash", "/workspace/.devcontainer/postAttach.sh"]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+services:
+  django:
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    command: sleep infinity
+    volumes:
+      - built-static:/workspace/django/static_built:ro
+      - .:/workspace

--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /workspace/django/
+poetry install 2>&1

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Custom
 node/
-.vscode/
+.vscode/settings.json
 package/
 .env
 *.service-account.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Django",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/django/manage.py",
+            "console": "integratedTerminal",
+            "args": ["runserver", "0.0.0.0:8000"],
+            "django": true
+        }
+    ]
+}

--- a/django/.gitignore
+++ b/django/.gitignore
@@ -99,3 +99,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+static_built/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3.8"
 
 services:
   db:
@@ -40,10 +40,9 @@ services:
       context: .
       dockerfile: ./docker/builder.Dockerfile
     volumes:
-      - built-static:/app/build/
-      - type: bind
-        source: ./builder/gulpfile.js
-        target: /app/gulpfile.js
+      - built-static:/home/node/app/build
+      - ./builder/src:/home/node/app/src:ro
+      - ./builder/gulpfile.js:/home/node/app/gulpfile.js:ro
 
 volumes:
   db-data:

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -1,9 +1,11 @@
-FROM node:12.2.0-alpine
+FROM node:12-alpine
 
-WORKDIR /app
-COPY ./builder/package.json ./builder/package-lock.json /app/
+RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+WORKDIR /home/node/app
+COPY --chown=node:node ./builder/package.json ./builder/package-lock.json ./
+USER node
 RUN npm ci
-COPY ./builder /app
+COPY --chown=node:node ./builder ./
 
 ENTRYPOINT ["npm", "run"]
 CMD ["watch"]


### PR DESCRIPTION
Closes #185
Replaces #189

- [x] Python testing window
  - [x] All tests
  - [x] Specific file
  - [x] Specific test
- [x] mypy
  - [x] `mypy.ini` used
  - [x] Plugins
  - [x] Errors shown in the IDE
- [ ] Codespaces works (#192)
- [x] Everything is automatically (and quickly) reloaded
  - [x] Backend
  - [x] Frontend
  - [x] Static assets
- [x] No requirements on the host
- [x] The `django` image should not have to be rebuilt often
- [x] If there is a syntax error resulting in the web server failing to start, the container should continue running and the web server should attempt to restart
- [x] Mounts should not create `root`-owned files
  - [x] A non-root user with UID `1000` and GID `1000` should be used