### PR TITLE
Use StaticFilesStorage when running with pytest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
           docker run --rm
           --entrypoint pytest
           -e SECRET_KEY=hunter2
+          -e DEV_TESTING=0
           --no-healthcheck
           thunderstore:latest
       - name: Tag image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
           docker run --rm
           --entrypoint pytest
           -e SECRET_KEY=hunter2
+          -e DEV_TESTING=0
           -v "$(pwd)/coverage_results:/app/coverage_results"
           --no-healthcheck
           thunderstore:${GITHUB_SHA}

--- a/django/pytest.ini
+++ b/django/pytest.ini
@@ -5,5 +5,6 @@ addopts = --reuse-db --nomigrations
 env =
     DATABASE_URL=sqlite:///tmp/django.db
     DEBUG="True"
+    TESTING=1
     DEBUG_TOOLBAR_ENABLED=0
     ALLOWED_HOSTS=testsite.test

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -17,6 +17,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 
 env = environ.Env(
     DEBUG=(bool, False),
+    TESTING=(bool, False),
     DEBUG_SIMULATED_LAG=(int, 0),
     DEBUG_TOOLBAR_ENABLED=(bool, False),
     DATABASE_URL=(str, "sqlite:///database/default.db"),
@@ -72,6 +73,7 @@ if not os.path.exists(checkout_dir("manage.py")):
     raise RuntimeError("Could not locate manage.py")
 
 DEBUG = env.bool("DEBUG")
+TESTING = env.bool("TESTING")
 DEBUG_SIMULATED_LAG = env.int("DEBUG_SIMULATED_LAG")
 
 SECRET_KEY = env.str("SECRET_KEY")
@@ -217,7 +219,10 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static_built"),
 ]
 
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+if TESTING:
+    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+else:
+    STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 
 # Internationalization

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -18,6 +18,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 env = environ.Env(
     DEBUG=(bool, False),
     TESTING=(bool, False),
+    DEV_TESTING=(bool, True),
     DEBUG_SIMULATED_LAG=(int, 0),
     DEBUG_TOOLBAR_ENABLED=(bool, False),
     DATABASE_URL=(str, "sqlite:///database/default.db"),
@@ -74,6 +75,7 @@ if not os.path.exists(checkout_dir("manage.py")):
 
 DEBUG = env.bool("DEBUG")
 TESTING = env.bool("TESTING")
+DEV_TESTING = env.bool("DEV_TESTING")
 DEBUG_SIMULATED_LAG = env.int("DEBUG_SIMULATED_LAG")
 
 SECRET_KEY = env.str("SECRET_KEY")
@@ -219,7 +221,7 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static_built"),
 ]
 
-if TESTING:
+if TESTING and DEV_TESTING:
     STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 else:
     STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"


### PR DESCRIPTION
This fixes `Missing staticfiles manifest entry` when running tests

Currently, when running pytest, `collectstatic` is required. This means new static files will raise errors until the command is ran. This switches the `STATICFILES_STORAGE` to a backend that does not require this. While running a dev server with `DEBUG` doesn't raise errors, pytest still does.

Based on "[ValueError: Missing staticfiles manifest entry for 'favicon.ico'](https://stackoverflow.com/questions/44160666/valueerror-missing-staticfiles-manifest-entry-for-favicon-ico)".

An alternative may be [`WHITENOISE_MANIFEST_STRICT`](https://whitenoise.evans.io/en/stable/django.html#WHITENOISE_MANIFEST_STRICT).