### PR TITLE
Change django service volumes to read-only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,11 @@ x-django-service: &django-service
     - db
     - redis
     - rabbitmq
+
+x-django-volumes: &django-volumes
   volumes:
     - django-data:/app/var
-    - ./django:/app
+    - ./django:/app:ro
     - built-static:/app/static_built:ro
 
 services:
@@ -46,18 +48,22 @@ services:
 
   django:
     <<: *django-service
+    volumes:
+      - django-data:/app/var
+      - ./django:/app
+      - built-static:/app/static_built:ro
     ports:
       - 127.0.0.1:80:8000
 
   django-worker:
-    <<: *django-service
+    <<: [*django-service, *django-volumes]
     entrypoint: watchmedo
     command: >
       auto-restart --patterns="*.py" --ignore-directories --recursive -d ./ --
       celery -A thunderstore.core worker -l INFO
 
   django-beat:
-    <<: *django-service
+    <<: [*django-service, *django-volumes]
     entrypoint: watchmedo
     command: >
       auto-restart --patterns="*.py" --ignore-directories --recursive -d ./ --

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ x-django-service: &django-service
 
 x-django-volumes: &django-volumes
   volumes:
-    - django-data:/app/var
+    - django-data:/app/var:ro
     - ./django:/app:ro
     - built-static:/app/static_built:ro
 


### PR DESCRIPTION
This makes all Django services other than `django` use read-only bind mounts to avoid permission issues when using the devcontainer. New services should follow this to avoid having to make a second devcontainer-specific image which uses a non-root main user.