### PR TITLE
Add support for PgBouncer transaction-level connection pooling

### DIFF
--- a/django/pytest.ini
+++ b/django/pytest.ini
@@ -3,7 +3,6 @@ DJANGO_SETTINGS_MODULE = thunderstore.core.settings
 norecursedirs = static var htmlcov
 addopts = --reuse-db --nomigrations
 env =
-    DATABASE_URL=sqlite:///tmp/django.db
     DEBUG="True"
     DEBUG_TOOLBAR_ENABLED=0
     ALLOWED_HOSTS=testsite.test

--- a/django/thunderstore/core/settings.py
+++ b/django/thunderstore/core/settings.py
@@ -20,6 +20,7 @@ env = environ.Env(
     DEBUG_SIMULATED_LAG=(int, 0),
     DEBUG_TOOLBAR_ENABLED=(bool, False),
     DATABASE_URL=(str, "sqlite:///database/default.db"),
+    DISABLE_SERVER_SIDE_CURSORS=(bool, True),
     SECRET_KEY=(str, ""),
     ALLOWED_HOSTS=(list, []),
     PROTOCOL=(str, ""),
@@ -83,6 +84,9 @@ ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")
 
 
 DATABASES = {"default": env.db()}
+DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = env.bool(
+    "DISABLE_SERVER_SIDE_CURSORS"
+)
 
 DB_CERT_DIR = env.str("DB_CERT_DIR")
 DB_CLIENT_CERT = env.str("DB_CLIENT_CERT")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     environment:
       DATABASE_URL: "postgres://django:django@db/django"
       POOL_MODE: "transaction"
+    volumes:
+      - ./pgbouncer.ini:/etc/pgbouncer/pgbouncer.ini:ro
     logging:
       driver: none
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       - built-static:/app/static_built:ro
     ports:
       - 127.0.0.1:80:8000
+    depends_on:
+      - builder
 
   django-worker:
     <<: [*django-service, *django-volumes]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ x-django-service: &django-service
     dockerfile: ./Dockerfile
   environment:
     CELERY_BROKER_URL: "pyamqp://django:django@rabbitmq/django"
+    DATABASE_URL: "psql://django:django@dbpool/django"
   env_file:
     - .env
   depends_on:
@@ -28,6 +29,14 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - db-data:/var/lib/postgresql/data
+
+  dbpool:
+    image: edoburu/pgbouncer:1.11.0
+    environment:
+      DATABASE_URL: "postgres://django:django@db/django"
+      POOL_MODE: "transaction"
+    logging:
+      driver: none
 
   redis:
     image: redis:5.0.4-alpine3.9

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -1,6 +1,7 @@
 FROM node:12-alpine
 
-RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+RUN mkdir -p /home/node/app/node_modules && mkdir /home/node/app/build && chown -R node:node /home/node/app
+VOLUME /home/node/app/build
 WORKDIR /home/node/app
 COPY --chown=node:node ./builder/package.json ./builder/package-lock.json ./
 USER node

--- a/pgbouncer.ini
+++ b/pgbouncer.ini
@@ -1,0 +1,24 @@
+################## Auto generated ##################
+[databases]
+django = host=db port=5432 user=django
+test_django = host=db port=5432 user=django
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 5432
+unix_socket_dir =
+user = postgres
+auth_file = /etc/pgbouncer/userlist.txt
+auth_type = md5
+pool_mode = transaction
+ignore_startup_parameters = extra_float_digits
+
+# Log settings
+admin_users = postgres
+
+# Connection sanity checks, timeouts
+
+# TLS settings
+
+# Dangerous timeouts
+################## end file ##################


### PR DESCRIPTION
Add support for transaction-level database connection pooling via PgBouncer. To ensure consistency with the production environment, also include PgBouncer in the development environment and configure Django tests to run through it.


To-do:

- [ ] Add PgBouncer to the CI test runtime. A good approach would be to run CI tests through docker-compose as well.