### PR TITLE
Stop running pull request workflow on internal PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on: [push, pull_request]
 
 jobs:
   pre-commit:
+    # Do not run pull_request workflow if the head repo is not a fork
+    # These are already tested with the push event
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.head.repo.fork)
+
     name: Run pre-commit
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This will stop:
- Waiting for 2 workflows to complete that are doing the same thing
- Having codecov updated twice for the same commit
- Having two Docker images pushed to the same tag (based on commit SHA) which might not be the same
  - Commit images are expected to be static